### PR TITLE
Quote WORKDIR directory existence in lynis

### DIFF
--- a/lynis
+++ b/lynis
@@ -76,7 +76,7 @@
         tINCLUDE_TARGETS="/usr/local/include/lynis /usr/local/lynis/include /usr/share/lynis/include ./include"  # Default paths to check (CWD as last option, in case we run from standalone)
         for I in ${tINCLUDE_TARGETS}; do
             if [ "${I}" = "./include" ]; then
-                if [ -d ${WORKDIR}/include ]; then INCLUDEDIR="${WORKDIR}/include"; fi
+                if [ -d "${WORKDIR}/include" ]; then INCLUDEDIR="${WORKDIR}/include"; fi
             elif [ -d ${I} -a -z "${INCLUDEDIR}" ]; then
                 INCLUDEDIR=${I}
             fi
@@ -95,7 +95,7 @@ Make sure to execute ${PROGRAM_NAME} from untarred directory or check your insta
         DBDIR=""; tDB_TARGETS="/usr/local/share/lynis/db /usr/local/lynis/db /usr/share/lynis/db ./db"
         for I in ${tDB_TARGETS}; do
             if [ "${I}" = "./db" ]; then
-                if [ -d ${WORKDIR}/db ]; then DBDIR="${WORKDIR}/db"; fi
+                if [ -d "${WORKDIR}/db" ]; then DBDIR="${WORKDIR}/db"; fi
             elif [ -d ${I} -a -z "${DBDIR}" ]; then
                 DBDIR="${I}"
             fi


### PR DESCRIPTION
Quote both "${WORKDIR}/include" and "${WORKDIR}/db" directory existence check in if-statements to avoid "Fatal error: can't find directory" in case of a space-character in the ${WORKDIR} path.